### PR TITLE
Add .vscode config files to better integrate with Azure Static Web Apps extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-azuretools.vscode-azurestaticwebapps"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "staticWebApps.outputSubpath": "dist/angular-basic"
+}


### PR DESCRIPTION
👋

My name is Alex and I'm working on adding better support for templates in the [Azure Static Web Apps VS Code extension](https://github.com/microsoft/vscode-azurestaticwebapps).

This PR has two additions:

1. Adding `staticWebApps.outputSubpath` setting with a value of `dist/angular-basic` in `.vscode/settings.json`

This addition makes it so that users can accept the default configurations when deploying this template via the Azure Static Web Apps VS Code extension. Adding the setting allows us to prefill the prompt with the correct configuration for this template. Before now, if the user selected the defaults then the template would fail to build once pushed/deployed to GitHub/Azure. Which is a really terrible 😢  experience for new users that we'd love to prevent.

Screenshot:
![image](https://user-images.githubusercontent.com/12476526/127386788-fa783af2-d029-407e-98fe-3f32fc5a514d.png)

See related issues if you want more context:
* https://github.com/microsoft/vscode-azurestaticwebapps/issues/453
* https://github.com/microsoft/vscode-azurestaticwebapps/issues/277#issuecomment-887594428

2. Adding `ms-azuretools.vscode-azurestaticwebapps` to recommended extensions in `.vscode/extensions.json`

More details about what we are planning for the "Create from template" feature in our extension:
* https://github.com/microsoft/vscode-azurestaticwebapps/issues/452